### PR TITLE
Fix GitHub plugin: MaxBytesReader, webhook routing, dynamic step fields

### DIFF
--- a/internal/module_webhook.go
+++ b/internal/module_webhook.go
@@ -100,12 +100,9 @@ func (m *webhookModule) SetMessageSubscriber(_ sdk.MessageSubscriber) {}
 // Init is a no-op; the module is ready after construction.
 func (m *webhookModule) Init() error { return nil }
 
-// Start registers the HTTP webhook handler with the global mux.
-// The engine must be running its HTTP server for this to receive requests.
-func (m *webhookModule) Start(_ context.Context) error {
-	http.HandleFunc("/webhooks/github", m.handleWebhook)
-	return nil
-}
+// Start is a no-op; the webhook route is declared via ConfigFragment so the
+// engine's HTTP server registers it through the normal config pipeline.
+func (m *webhookModule) Start(_ context.Context) error { return nil }
 
 // Stop is a no-op.
 func (m *webhookModule) Stop(_ context.Context) error { return nil }

--- a/internal/resolve.go
+++ b/internal/resolve.go
@@ -1,0 +1,92 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+// resolveField performs basic template resolution on value, replacing
+// {{.field}} references with values looked up from triggerData, stepOutputs,
+// and current (in that priority order).
+//
+// Supported reference forms:
+//
+//	{{.field}}                     — look up "field" in triggerData
+//	{{.steps.stepName.field}}      — look up stepOutputs["stepName"]["field"]
+//	{{.current.field}}             — look up "field" in current
+//
+// If the placeholder cannot be resolved the original placeholder text is left
+// in place so misconfiguration is visible rather than silently swallowed.
+func resolveField(value string, triggerData map[string]any, stepOutputs map[string]map[string]any, current map[string]any) string {
+	if !strings.Contains(value, "{{") {
+		return value
+	}
+
+	result := value
+	// Iterate until no more replacements can be made (handles multiple refs).
+	for strings.Contains(result, "{{") {
+		start := strings.Index(result, "{{")
+		end := strings.Index(result, "}}")
+		if end < start {
+			break
+		}
+		placeholder := result[start : end+2]
+		inner := strings.TrimSpace(result[start+2 : end])
+
+		resolved, ok := lookupRef(inner, triggerData, stepOutputs, current)
+		if ok {
+			result = strings.Replace(result, placeholder, fmt.Sprintf("%v", resolved), 1)
+		} else {
+			// Leave the unresolvable placeholder and stop to avoid an infinite loop.
+			break
+		}
+	}
+	return result
+}
+
+// lookupRef resolves a single template reference (the content between {{ and }}).
+func lookupRef(ref string, triggerData map[string]any, stepOutputs map[string]map[string]any, current map[string]any) (any, bool) {
+	// Strip leading dot.
+	ref = strings.TrimPrefix(ref, ".")
+
+	parts := strings.SplitN(ref, ".", 3)
+
+	switch parts[0] {
+	case "steps":
+		// {{.steps.<stepName>.<field>}}
+		if len(parts) < 3 {
+			return nil, false
+		}
+		stepName, field := parts[1], parts[2]
+		if stepOutputs == nil {
+			return nil, false
+		}
+		outputs, ok := stepOutputs[stepName]
+		if !ok {
+			return nil, false
+		}
+		v, ok := outputs[field]
+		return v, ok
+
+	case "current":
+		// {{.current.<field>}}
+		if len(parts) < 2 {
+			return nil, false
+		}
+		field := strings.Join(parts[1:], ".")
+		if current == nil {
+			return nil, false
+		}
+		v, ok := current[field]
+		return v, ok
+
+	default:
+		// {{.field}} — look up directly in triggerData.
+		field := strings.Join(parts, ".")
+		if triggerData == nil {
+			return nil, false
+		}
+		v, ok := triggerData[field]
+		return v, ok
+	}
+}


### PR DESCRIPTION
## Summary

- **fix: replace `MaxBytesReader(nil)` with `io.LimitReader`** (`internal/module_webhook.go`) — `http.MaxBytesReader` requires a non-nil `ResponseWriter`; passing `nil` caused a nil-pointer panic on large payloads. Replaced with `io.LimitReader` + an explicit size check.
- **fix: remove `DefaultServeMux` registration, expose webhook route via `ConfigFragment`** (`internal/module_webhook.go`, `internal/plugin.go`) — `http.HandleFunc` registers on the global `DefaultServeMux` which is unreachable from a gRPC plugin process. The `Start()` method is now a no-op; the `/webhooks/github` route is declared via `ConfigFragment()` so the engine's HTTP server registers it through the normal config pipeline.
- **fix: wire pipeline context into step `Execute` methods for dynamic field resolution** (`internal/resolve.go`, `internal/step_action_status.go`, `internal/step_action_trigger.go`, `internal/step_create_check.go`) — All three step types previously ignored `triggerData`, `stepOutputs`, and `current`, making `{{.field}}` references in `owner`, `repo`, `sha`, `ref`, `workflow`, `inputs`, and `run_id` silently inoperative. A new `resolveField` helper (with `lookupRef`) substitutes `{{.field}}`, `{{.steps.<name>.<field>}}`, and `{{.current.<field>}}` references at execute time.

## Test plan

- [x] `go build ./...` — no errors
- [x] `go test ./...` — all tests pass (`ok github.com/GoCodeAlone/workflow-plugin-github/internal`)
- [ ] Deploy to a workflow engine instance and send a POST to `/webhooks/github` to confirm the route is reachable and large-body rejection works
- [ ] Configure a pipeline step with `{{.steps.trigger.run_id}}` in `run_id` and confirm dynamic resolution populates the correct value at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)