### PR TITLE
ci: publish GoReleaser drafts after artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPRIVATE: github.com/GoCodeAlone/*
           GONOSUMCHECK: github.com/GoCodeAlone/*
+      - name: Publish GitHub release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false --repo "${{ github.repository }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,7 @@ checksum:
   name_template: "checksums.txt"
 
 release:
+  draft: true
   github:
     owner: GoCodeAlone
     name: workflow-plugin-github


### PR DESCRIPTION
## Summary
- configure GoReleaser to keep GitHub releases as drafts while artifacts are uploaded
- publish the draft release only after the release workflow completes artifact/registry steps
- keep release workflows compatible with GitHub immutable releases

## Verification
- actionlint on changed GoReleaser release workflow
- git diff --check
