### PR TITLE
chore: sync plugin.json version to latest tag v

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "workflow-plugin-github",
-    "version": "1.0.1",
+    "version": "1.0.3",
     "description": "GitHub integration plugin: webhook handling, GitHub Actions, PRs, issues, releases, and deployments",
     "author": "GoCodeAlone",
     "license": "MIT",


### PR DESCRIPTION
Sync the `version` field in `plugin.json` to match the latest git release tag, eliminating drift between the published tag and the manifest the registry/consumers read.

**Change:** `version` field updated to match latest tag.

This is a pure metadata sync — no code changes.