### PR TITLE
chore: advertise required_secrets[] (GITHUB_APP_PRIVATE_KEY)

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,6 +7,14 @@
     "type": "external",
     "tier": "community",
     "minEngineVersion": "0.61.0",
+    "required_secrets": [
+        {
+            "name": "GITHUB_APP_PRIVATE_KEY",
+            "sensitive": true,
+            "description": "GitHub App private key (PEM) for the github.app module. Referenced as ${GITHUB_APP_PRIVATE_KEY} in private_key. (Step-level operations may also use a GITHUB_TOKEN.)",
+            "prompt": "GitHub App private key (PEM)"
+        }
+    ],
     "keywords": ["github", "webhook", "git", "actions", "ci", "cd", "integration", "pull-request", "release"],
     "homepage": "https://github.com/GoCodeAlone/workflow-plugin-github",
     "repository": "https://github.com/GoCodeAlone/workflow-plugin-github",


### PR DESCRIPTION
Advertise required_secrets[] so 'wfctl secrets setup --plugin github' provisions credentials uniformly. Part of the ecosystem sweep (workspace docs/plans/2026-05-31-plugin-required-secrets-sweep*; ADR 0006). Source-of-truth mirror of the workflow-registry manifest. No release. Names verified per design §4. Copilot not requested (down).