### PR TITLE
ci: modernize action pins and Go baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
       - name: Configure git for private modules
         run: git config --global url."https://${{ secrets.RELEASES_TOKEN }}@github.com/".insteadOf "https://github.com/"
       - run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,34 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
-      - uses: GoCodeAlone/setup-wfctl@v1
-        with:
-          version: v0.63.2
+          cache: false
+      - name: Install wfctl v0.74.6
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || github.token }}
+          WFCTL_VERSION: v0.74.6
+        run: |
+          set -euo pipefail
+          runner_arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          asset="wfctl-linux-${runner_arch}"
+          download_dir="$(mktemp -d)"
+          gh release download "${WFCTL_VERSION}" \
+            --repo GoCodeAlone/workflow \
+            --pattern "${asset}" \
+            --pattern checksums.txt \
+            --dir "${download_dir}"
+          (cd "${download_dir}" && grep "  ${asset}$" checksums.txt | sha256sum -c -)
+          mkdir -p "${RUNNER_TEMP}/wfctl-bin"
+          install -m 0755 "${download_dir}/${asset}" "${RUNNER_TEMP}/wfctl-bin/wfctl"
+          echo "${RUNNER_TEMP}/wfctl-bin" >> "$GITHUB_PATH"
       - name: Validate plugin contract for publish (pre-build)
         run: wfctl plugin validate-contract --for-publish --tag "${{ github.ref_name }}" .
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           distribution: goreleaser
           version: '~> v2'
@@ -67,7 +83,7 @@ jobs:
       && github.repository == 'GoCodeAlone/workflow-plugin-github'
     steps:
       - name: Trigger registry manifest sync
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697  # v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.repo_dispatch_token }}
           repository: GoCodeAlone/workflow-registry

--- a/.github/workflows/wfctl-validate.yml
+++ b/.github/workflows/wfctl-validate.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check plugin.json and plugin.contracts.json exist
         run: |
@@ -25,10 +25,24 @@ jobs:
             exit 1
           fi
 
-      - uses: GoCodeAlone/setup-wfctl@bcd880980f5bbe8d192d0c20ff6279d25331f956
-        with:
-          version: latest
-          token: ${{ secrets.RELEASES_TOKEN }}
+      - name: Install wfctl v0.74.6
+        env:
+          GH_TOKEN: ${{ secrets.RELEASES_TOKEN || github.token }}
+          WFCTL_VERSION: v0.74.6
+        run: |
+          set -euo pipefail
+          runner_arch=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
+          asset="wfctl-linux-${runner_arch}"
+          download_dir="$(mktemp -d)"
+          gh release download "${WFCTL_VERSION}" \
+            --repo GoCodeAlone/workflow \
+            --pattern "${asset}" \
+            --pattern checksums.txt \
+            --dir "${download_dir}"
+          (cd "${download_dir}" && grep "  ${asset}$" checksums.txt | sha256sum -c -)
+          mkdir -p "${RUNNER_TEMP}/wfctl-bin"
+          install -m 0755 "${download_dir}/${asset}" "${RUNNER_TEMP}/wfctl-bin/wfctl"
+          echo "${RUNNER_TEMP}/wfctl-bin" >> "$GITHUB_PATH"
 
       - name: Validate strict plugin contracts
         run: wfctl plugin validate --file plugin.json --strict-contracts

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoCodeAlone/workflow-plugin-github
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/GoCodeAlone/workflow v0.64.0


### PR DESCRIPTION
## Summary
- pin CI/release/contract workflows to audited action SHAs with version comments
- bump the module Go directive to 1.26.4
- install wfctl v0.74.6 directly from the release with checksum verification

## Verification
- actionlint .github/workflows/*.yml
- GOWORK=off go test ./...
