### PR TITLE
fix: correct GitLab secret target scope

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -607,15 +607,14 @@
           ],
           "description": "Stored as GitHub Actions secrets when workflows run on GitHub."
         },
-        {
-          "provider": "gitlab",
-          "scopes": [
-            "project",
-            "group",
-            "env"
-          ],
-          "description": "Stored as GitLab CI/CD variables when workflows run on GitLab."
-        },
+      {
+        "provider": "gitlab",
+        "scopes": [
+          "project",
+          "group"
+        ],
+        "description": "Stored as GitLab CI/CD variables when workflows run on GitLab; variables may also be narrowed with GitLab environment_scope."
+      },
         {
           "provider": "vault",
           "scopes": [


### PR DESCRIPTION
## Summary
- remove stale gitlab env scope from secret_targets
- document GitLab environment narrowing as environment_scope on project/group variables

## Validation
- jq empty plugin.json
- /tmp/wfctl-env-contract plugin validate -file plugin.json
- /tmp/wfctl-env-contract plugin validate-contract .
- GOWORK=off go test ./...