### PR TITLE
Add GitHub runner dynamic provider runtime image

### DIFF
--- a/cmd/github-actions-runner-job/Dockerfile
+++ b/cmd/github-actions-runner-job/Dockerfile
@@ -1,0 +1,13 @@
+ARG ACTIONS_RUNNER_IMAGE=ghcr.io/actions/actions-runner:2.333.1
+FROM ${ACTIONS_RUNNER_IMAGE}
+
+ARG TARGETARCH
+ARG RUNNER_JOB_BINARY=dist/github-actions-runner-job-linux-${TARGETARCH}
+
+USER root
+COPY --chmod=0755 ${RUNNER_JOB_BINARY} /usr/local/bin/github-actions-runner-job
+
+USER runner
+WORKDIR /home/runner
+ENV GITHUB_ACTIONS_RUNNER_DIR=/home/runner
+ENTRYPOINT ["/usr/local/bin/github-actions-runner-job"]

--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -1,12 +1,27 @@
 package main
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/GoCodeAlone/workflow-plugin-github/internal"
+)
+
+const (
+	computeProtocolVersion = "compute.v1alpha1"
+	providerOperation      = "ephemeral_runner_job"
+	proofArtifactName      = "github-runner-proof.json"
 )
 
 func main() {
@@ -17,25 +32,267 @@ func main() {
 }
 
 func run() error {
-	specOnly := flag.Bool("spec", false, "emit the deterministic runner spec without starting a runner")
-	flag.Parse()
-	if !*specOnly {
-		return fmt.Errorf("runner execution is not available without a host-provided execution driver; use --spec only for preflight/spec generation")
+	return runWithIO(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)
+}
+
+func runWithIO(args []string, stdin io.Reader, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("github-actions-runner-job", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	specOnly := fs.Bool("spec", false, "emit the deterministic runner spec without starting a runner")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	return runParsed(*specOnly, stdin, stdout)
+}
+
+func runParsed(specOnly bool, stdin io.Reader, stdout io.Writer) error {
+	if specOnly {
+		var req internal.EphemeralRunnerJobRequest
+		decoder := json.NewDecoder(stdin)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&req); err != nil {
+			return fmt.Errorf("decode request: %w", err)
+		}
+		spec, err := internal.BuildEphemeralRunnerJobSpec(req)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(stdout).Encode(map[string]any{
+			"runner_name":  spec.RunnerName,
+			"labels":       spec.Labels,
+			"runner_group": spec.RunnerGroup,
+		})
 	}
 
-	var req internal.EphemeralRunnerJobRequest
-	decoder := json.NewDecoder(os.Stdin)
+	var envelope dynamicProviderEnvelope
+	decoder := json.NewDecoder(stdin)
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&req); err != nil {
-		return fmt.Errorf("decode request: %w", err)
+	if err := decoder.Decode(&envelope); err != nil {
+		return fmt.Errorf("decode dynamic provider envelope: %w", err)
 	}
-	spec, err := internal.BuildEphemeralRunnerJobSpec(req)
+	if err := envelope.validate(); err != nil {
+		return err
+	}
+	var req internal.EphemeralRunnerJobRequest
+	if err := json.Unmarshal(envelope.Input, &req); err != nil {
+		return fmt.Errorf("decode ephemeral runner request: %w", err)
+	}
+	sidecar, err := newSidecarClientFromEnv()
 	if err != nil {
 		return err
 	}
-	return json.NewEncoder(os.Stdout).Encode(map[string]any{
-		"runner_name":  spec.RunnerName,
-		"labels":       spec.Labels,
-		"runner_group": spec.RunnerGroup,
-	})
+	driver, err := newRunnerDriver(req, sidecar)
+	if err != nil {
+		return err
+	}
+	result, err := internal.NewEphemeralRunnerJob(driver).Run(context.Background(), req)
+	if proofErr := writeProofArtifact(result); proofErr != nil && err == nil {
+		err = proofErr
+	}
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(stdout).Encode(map[string]any{"artifacts": []string{proofArtifactName}})
+}
+
+type dynamicProviderEnvelope struct {
+	ProtocolVersion string          `json:"protocol_version"`
+	TaskID          string          `json:"task_id"`
+	LeaseID         string          `json:"lease_id"`
+	ProviderConfig  json.RawMessage `json:"provider_config"`
+	Operation       string          `json:"operation"`
+	Input           json.RawMessage `json:"input"`
+}
+
+func (e dynamicProviderEnvelope) validate() error {
+	if e.ProtocolVersion != computeProtocolVersion {
+		return fmt.Errorf("protocol_version must be %q", computeProtocolVersion)
+	}
+	if strings.TrimSpace(e.TaskID) == "" {
+		return fmt.Errorf("task_id is required")
+	}
+	if strings.TrimSpace(e.LeaseID) == "" {
+		return fmt.Errorf("lease_id is required")
+	}
+	if strings.TrimSpace(e.Operation) != providerOperation {
+		return fmt.Errorf("operation must be %q", providerOperation)
+	}
+	if len(e.ProviderConfig) == 0 || !json.Valid(e.ProviderConfig) {
+		return fmt.Errorf("provider_config must be valid JSON")
+	}
+	if len(e.Input) == 0 || !json.Valid(e.Input) {
+		return fmt.Errorf("input must be valid JSON")
+	}
+	return nil
+}
+
+type providerSidecarClient struct {
+	baseURL string
+	token   string
+	http    *http.Client
+}
+
+func newSidecarClientFromEnv() (*providerSidecarClient, error) {
+	baseURL := strings.TrimSpace(os.Getenv("COMPUTE_GITHUB_RUNNER_PROVIDER_URL"))
+	if baseURL == "" {
+		return nil, fmt.Errorf("COMPUTE_GITHUB_RUNNER_PROVIDER_URL is required")
+	}
+	token := strings.TrimSpace(os.Getenv("COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN"))
+	if token == "" {
+		return nil, fmt.Errorf("COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN is required")
+	}
+	return &providerSidecarClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		http:    &http.Client{Timeout: 30 * time.Second},
+	}, nil
+}
+
+func (c *providerSidecarClient) orgRegistrationToken(ctx context.Context, organization string) (internal.GitHubRunnerRegistrationToken, error) {
+	var out internal.GitHubRunnerRegistrationToken
+	if err := c.do(ctx, http.MethodPost, "/v1/actions/orgs/"+organization+"/runners/registration-token", nil, http.StatusCreated, &out); err != nil {
+		return internal.GitHubRunnerRegistrationToken{}, err
+	}
+	return out, nil
+}
+
+func (c *providerSidecarClient) dispatchWorkflow(ctx context.Context, repository, workflow, ref string) error {
+	owner, repo, err := splitRepository(repository)
+	if err != nil {
+		return err
+	}
+	path := "/v1/actions/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/workflows/" + url.PathEscape(workflow) + "/dispatches"
+	return c.do(ctx, http.MethodPost, path, map[string]any{"ref": ref}, http.StatusNoContent, nil)
+}
+
+func (c *providerSidecarClient) do(ctx context.Context, method, path string, body any, wantStatus int, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal sidecar request: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("provider sidecar request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != wantStatus {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("provider sidecar %s %s: status %d: %s", method, path, resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode provider sidecar response: %w", err)
+		}
+	}
+	return nil
+}
+
+type runnerDriver struct {
+	req       internal.EphemeralRunnerJobRequest
+	sidecar   *providerSidecarClient
+	runnerDir string
+}
+
+func newRunnerDriver(req internal.EphemeralRunnerJobRequest, sidecar *providerSidecarClient) (*runnerDriver, error) {
+	runnerDir := strings.TrimSpace(os.Getenv("GITHUB_ACTIONS_RUNNER_DIR"))
+	if runnerDir == "" {
+		runnerDir = "/opt/actions-runner"
+	}
+	return &runnerDriver{req: req, sidecar: sidecar, runnerDir: runnerDir}, nil
+}
+
+func (d *runnerDriver) OrgRegistrationToken(ctx context.Context, organization string) (internal.GitHubRunnerRegistrationToken, error) {
+	return d.sidecar.orgRegistrationToken(ctx, organization)
+}
+
+func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.EphemeralRunnerJobMode, spec internal.EphemeralRunnerJobSpec, token internal.GitHubRunnerRegistrationToken) (internal.EphemeralRunnerJobResult, error) {
+	if mode == "" {
+		mode = internal.EphemeralRunnerJobModeAttachToQueued
+	}
+	if mode == internal.EphemeralRunnerJobModeDispatchThenWait {
+		if strings.TrimSpace(d.req.Workflow) == "" || strings.TrimSpace(d.req.Repository) == "" {
+			return internal.EphemeralRunnerJobResult{}, fmt.Errorf("repository and workflow are required for %s", mode)
+		}
+		ref := strings.TrimSpace(d.req.Ref)
+		if ref == "" {
+			ref = "main"
+		}
+		if err := d.sidecar.dispatchWorkflow(ctx, d.req.Repository, d.req.Workflow, ref); err != nil {
+			return internal.EphemeralRunnerJobResult{}, err
+		}
+	}
+	if err := d.configureRunner(ctx, spec, token.Token); err != nil {
+		return internal.EphemeralRunnerJobResult{}, err
+	}
+	if err := d.runRunner(ctx); err != nil {
+		return internal.EphemeralRunnerJobResult{}, err
+	}
+	return internal.EphemeralRunnerJobResult{
+		RunnerName:    spec.RunnerName,
+		Labels:        append([]string(nil), spec.Labels...),
+		CleanupStatus: "removed",
+	}, nil
+}
+
+func (d *runnerDriver) RemoveOrgRunner(context.Context, string, int64) error {
+	return nil
+}
+
+func (d *runnerDriver) configureRunner(ctx context.Context, spec internal.EphemeralRunnerJobSpec, token string) error {
+	args := []string{
+		"--url", "https://github.com/" + d.req.Organization,
+		"--token", token,
+		"--name", spec.RunnerName,
+		"--labels", strings.Join(spec.Labels, ","),
+		"--unattended",
+		"--ephemeral",
+		"--replace",
+	}
+	if strings.TrimSpace(spec.RunnerGroup) != "" {
+		args = append(args, "--runnergroup", spec.RunnerGroup)
+	}
+	return runCommand(ctx, filepath.Join(d.runnerDir, "config.sh"), d.runnerDir, args...)
+}
+
+func (d *runnerDriver) runRunner(ctx context.Context) error {
+	return runCommand(ctx, filepath.Join(d.runnerDir, "run.sh"), d.runnerDir)
+}
+
+func runCommand(ctx context.Context, path, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, path, args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w: %s", filepath.Base(path), err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func writeProofArtifact(result internal.EphemeralRunnerJobResult) error {
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(proofArtifactName, append(data, '\n'), 0o600)
+}
+
+func splitRepository(repository string) (string, string, error) {
+	owner, repo, ok := strings.Cut(strings.TrimSpace(repository), "/")
+	if !ok || owner == "" || repo == "" || strings.Contains(repo, "/") {
+		return "", "", fmt.Errorf("repository must be owner/name")
+	}
+	return owner, repo, nil
 }

--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -73,9 +73,9 @@ func runParsed(specOnly bool, stdin io.Reader, stdout io.Writer) error {
 	if err := envelope.validate(); err != nil {
 		return err
 	}
-	var req internal.EphemeralRunnerJobRequest
-	if err := json.Unmarshal(envelope.Input, &req); err != nil {
-		return fmt.Errorf("decode ephemeral runner request: %w", err)
+	req, err := decodeEphemeralRunnerRequest(envelope.Input)
+	if err != nil {
+		return err
 	}
 	sidecar, err := newSidecarClientFromEnv()
 	if err != nil {
@@ -126,6 +126,16 @@ func (e dynamicProviderEnvelope) validate() error {
 	return nil
 }
 
+func decodeEphemeralRunnerRequest(input json.RawMessage) (internal.EphemeralRunnerJobRequest, error) {
+	var req internal.EphemeralRunnerJobRequest
+	decoder := json.NewDecoder(bytes.NewReader(input))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		return internal.EphemeralRunnerJobRequest{}, fmt.Errorf("decode ephemeral runner request: %w", err)
+	}
+	return req, nil
+}
+
 type providerSidecarClient struct {
 	baseURL string
 	token   string
@@ -163,6 +173,11 @@ func (c *providerSidecarClient) dispatchWorkflow(ctx context.Context, repository
 	}
 	path := "/v1/actions/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/workflows/" + url.PathEscape(workflow) + "/dispatches"
 	return c.do(ctx, http.MethodPost, path, map[string]any{"ref": ref}, http.StatusNoContent, nil)
+}
+
+func (c *providerSidecarClient) removeOrgRunner(ctx context.Context, organization string, runnerID int64) error {
+	path := fmt.Sprintf("/v1/actions/orgs/%s/runners/%d", url.PathEscape(organization), runnerID)
+	return c.do(ctx, http.MethodDelete, path, nil, http.StatusNoContent, nil)
 }
 
 func (c *providerSidecarClient) do(ctx context.Context, method, path string, body any, wantStatus int, out any) error {
@@ -236,18 +251,20 @@ func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.Ephemeral
 	if err := d.configureRunner(ctx, spec, token.Token); err != nil {
 		return internal.EphemeralRunnerJobResult{}, err
 	}
+	runnerID := d.runnerID()
 	if err := d.runRunner(ctx); err != nil {
 		return internal.EphemeralRunnerJobResult{}, err
 	}
 	return internal.EphemeralRunnerJobResult{
+		RunnerID:      runnerID,
 		RunnerName:    spec.RunnerName,
 		Labels:        append([]string(nil), spec.Labels...),
 		CleanupStatus: "removed",
 	}, nil
 }
 
-func (d *runnerDriver) RemoveOrgRunner(context.Context, string, int64) error {
-	return nil
+func (d *runnerDriver) RemoveOrgRunner(ctx context.Context, organization string, runnerID int64) error {
+	return d.sidecar.removeOrgRunner(ctx, organization, runnerID)
 }
 
 func (d *runnerDriver) configureRunner(ctx context.Context, spec internal.EphemeralRunnerJobSpec, token string) error {
@@ -268,6 +285,20 @@ func (d *runnerDriver) configureRunner(ctx context.Context, spec internal.Epheme
 
 func (d *runnerDriver) runRunner(ctx context.Context) error {
 	return runCommand(ctx, filepath.Join(d.runnerDir, "run.sh"), d.runnerDir)
+}
+
+func (d *runnerDriver) runnerID() int64 {
+	data, err := os.ReadFile(filepath.Join(d.runnerDir, ".runner"))
+	if err != nil {
+		return 0
+	}
+	var metadata struct {
+		AgentID int64 `json:"agentId"`
+	}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return 0
+	}
+	return metadata.AgentID
 }
 
 func runCommand(ctx context.Context, path, dir string, args ...string) error {

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testing.T) {
-	var tokenCalls, dispatchCalls int
+	var tokenCalls, dispatchCalls, deleteCalls int
 	sidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer provider-token" {
 			t.Fatalf("authorization = %q", got)
@@ -25,6 +25,9 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches":
 			dispatchCalls++
 			w.WriteHeader(http.StatusNoContent)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/actions/orgs/GoCodeAlone/runners/42":
+			deleteCalls++
+			w.WriteHeader(http.StatusNoContent)
 		default:
 			t.Fatalf("unexpected sidecar request: %s %s", r.Method, r.URL.Path)
 		}
@@ -32,7 +35,7 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 	t.Cleanup(sidecar.Close)
 
 	runnerDir := t.TempDir()
-	writeExecutable(t, filepath.Join(runnerDir, "config.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/config.args\"\n")
+	writeExecutable(t, filepath.Join(runnerDir, "config.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/config.args\"\nprintf '{\"agentId\":42}\\n' > .runner\n")
 	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
 	workspace := t.TempDir()
 	t.Chdir(workspace)
@@ -64,8 +67,8 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 	if err := runWithIO([]string{}, input, &stdout, &stderr); err != nil {
 		t.Fatalf("run dynamic provider: %v\nstderr:\n%s", err, stderr.String())
 	}
-	if tokenCalls != 1 || dispatchCalls != 1 {
-		t.Fatalf("sidecar calls: token=%d dispatch=%d", tokenCalls, dispatchCalls)
+	if tokenCalls != 1 || dispatchCalls != 1 || deleteCalls != 1 {
+		t.Fatalf("sidecar calls: token=%d dispatch=%d delete=%d", tokenCalls, dispatchCalls, deleteCalls)
 	}
 	configArgs := readFile(t, filepath.Join(workspace, "config.args"))
 	for _, want := range []string{
@@ -97,6 +100,21 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 		if !strings.Contains(proof, want) {
 			t.Fatalf("proof missing %q:\n%s", want, proof)
 		}
+	}
+}
+
+func TestT915CommandRejectsUnknownDynamicInputFields(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runWithIO([]string{}, strings.NewReader(`{
+	  "protocol_version":"compute.v1alpha1",
+	  "task_id":"task-1",
+	  "lease_id":"lease-1",
+	  "provider_config":{"plugin_id":"workflow-plugin-github","provider_id":"github-actions-runner"},
+	  "operation":"ephemeral_runner_job",
+	  "input":{"environment":"stg","os":"linux","worker_id":"worker-1","task_id":"task-1","organization":"GoCodeAlone","typo":true}
+	}`), &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("error = %v, want strict unknown field rejection", err)
 	}
 }
 

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testing.T) {
+	var tokenCalls, dispatchCalls int
+	sidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer provider-token" {
+			t.Fatalf("authorization = %q", got)
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/actions/orgs/GoCodeAlone/runners/registration-token":
+			tokenCalls++
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"token":"runner-registration-token","expires_at":"2026-06-26T22:00:00Z"}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches":
+			dispatchCalls++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("unexpected sidecar request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	t.Cleanup(sidecar.Close)
+
+	runnerDir := t.TempDir()
+	writeExecutable(t, filepath.Join(runnerDir, "config.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/config.args\"\n")
+	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_URL", sidecar.URL)
+	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN", "provider-token")
+	t.Setenv("GITHUB_ACTIONS_RUNNER_DIR", runnerDir)
+	t.Setenv("GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR", workspace)
+
+	input := strings.NewReader(`{
+	  "protocol_version":"compute.v1alpha1",
+	  "task_id":"task-abcdef9876543210",
+	  "lease_id":"lease-1",
+	  "provider_config":{"plugin_id":"workflow-plugin-github","provider_id":"github-actions-runner"},
+	  "operation":"ephemeral_runner_job",
+	  "input":{
+	    "mode":"dispatch_then_wait",
+	    "environment":"stg",
+	    "os":"linux",
+	    "worker_id":"worker-0123456789abcdef",
+	    "task_id":"task-abcdef9876543210",
+	    "organization":"GoCodeAlone",
+	    "repository":"GoCodeAlone/workflow-compute",
+	    "workflow":"dogfood.yml",
+	    "ref":"main",
+	    "runner_group":"ephemeral"
+	  }
+	}`)
+	var stdout, stderr bytes.Buffer
+	if err := runWithIO([]string{}, input, &stdout, &stderr); err != nil {
+		t.Fatalf("run dynamic provider: %v\nstderr:\n%s", err, stderr.String())
+	}
+	if tokenCalls != 1 || dispatchCalls != 1 {
+		t.Fatalf("sidecar calls: token=%d dispatch=%d", tokenCalls, dispatchCalls)
+	}
+	configArgs := readFile(t, filepath.Join(workspace, "config.args"))
+	for _, want := range []string{
+		"--url\nhttps://github.com/GoCodeAlone",
+		"--token\nrunner-registration-token",
+		"--name\nwfc-stg-ghp-linux-01234567-abcdef98",
+		"--runnergroup\nephemeral",
+		"--labels\nself-hosted,linux,wfc-stg-ghp-linux-01234567-abcdef98,wfc-ghp-stg,wfc-ghp-ephemeral",
+		"--ephemeral",
+	} {
+		if !strings.Contains(configArgs, want) {
+			t.Fatalf("config args missing %q:\n%s", want, configArgs)
+		}
+	}
+	if got := readFile(t, filepath.Join(workspace, "run.log")); !strings.Contains(got, "runner executed") {
+		t.Fatalf("run script did not execute: %q", got)
+	}
+	var result struct {
+		Artifacts []string `json:"artifacts"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	if len(result.Artifacts) != 1 || result.Artifacts[0] != "github-runner-proof.json" {
+		t.Fatalf("artifacts = %#v", result.Artifacts)
+	}
+	proof := readFile(t, filepath.Join(workspace, "github-runner-proof.json"))
+	for _, want := range []string{"wfc-stg-ghp-linux-01234567-abcdef98", "task-abcdef9876543210", "removed"} {
+		if !strings.Contains(proof, want) {
+			t.Fatalf("proof missing %q:\n%s", want, proof)
+		}
+	}
+}
+
+func TestT915CommandRequiresSidecarEnvironmentForDynamicEnvelope(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := runWithIO([]string{}, strings.NewReader(`{
+	  "protocol_version":"compute.v1alpha1",
+	  "task_id":"task-1",
+	  "lease_id":"lease-1",
+	  "provider_config":{"plugin_id":"workflow-plugin-github","provider_id":"github-actions-runner"},
+	  "operation":"ephemeral_runner_job",
+	  "input":{"environment":"stg","os":"linux","worker_id":"worker-1","task_id":"task-1","organization":"GoCodeAlone"}
+	}`), &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "COMPUTE_GITHUB_RUNNER_PROVIDER_URL") {
+		t.Fatalf("error = %v, want missing sidecar env", err)
+	}
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write executable %s: %v", path, err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}

--- a/internal/module_runner_provider.go
+++ b/internal/module_runner_provider.go
@@ -32,6 +32,7 @@ type GitHubRunnerClient interface {
 	OrgRegistrationToken(ctx context.Context, organization, token string) (GitHubRunnerRegistrationToken, error)
 	RemoveOrgRunner(ctx context.Context, organization string, runnerID int64, token string) error
 	PreflightOrg(ctx context.Context, req GitHubRunnerProviderPreflightRequest, token string) (GitHubRunnerProviderPreflight, error)
+	DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref, token string) error
 }
 
 type GitHubRunnerRegistrationToken struct {
@@ -169,6 +170,14 @@ func (c *httpGitHubRunnerClient) PreflightOrg(ctx context.Context, req GitHubRun
 		ActionsEnabled:     true,
 		SelfHostedAllowed:  true,
 	}, nil
+}
+
+func (c *httpGitHubRunnerClient) DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref, token string) error {
+	if strings.TrimSpace(ref) == "" {
+		ref = "main"
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/actions/workflows/%s/dispatches", c.baseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(workflow))
+	return c.do(ctx, http.MethodPost, endpoint, map[string]any{"ref": ref}, token, http.StatusNoContent, nil)
 }
 
 func (c *httpGitHubRunnerClient) do(ctx context.Context, method, endpoint string, body any, token string, wantStatus int, out any) error {
@@ -405,6 +414,23 @@ func (m *githubRunnerProviderModule) invokeMethod(ctx context.Context, method st
 			return nil, err
 		}
 		return preflightMap(preflight), nil
+	case "dispatch_workflow":
+		owner, repo, repository, err := repositoryArg(args)
+		if err != nil {
+			return nil, err
+		}
+		if err := m.requireAllowedRepository(repository); err != nil {
+			return nil, err
+		}
+		workflow := stringArg(args, "workflow")
+		if workflow == "" {
+			return nil, errors.New("workflow is required")
+		}
+		ref := stringArg(args, "ref")
+		if err := m.client.DispatchWorkflow(ctx, owner, repo, workflow, ref, m.config.Token); err != nil {
+			return nil, err
+		}
+		return map[string]any{}, nil
 	case "ephemeral_runner_job":
 		req, err := ephemeralRunnerJobRequestFromArgs(args)
 		if err != nil {
@@ -435,6 +461,7 @@ func (m *githubRunnerProviderModule) HTTPHandler() http.Handler {
 	mux.HandleFunc("POST /v1/actions/orgs/{organization}/runners/registration-token", m.handleOrgRegistrationToken)
 	mux.HandleFunc("DELETE /v1/actions/orgs/{organization}/runners/{runner_id}", m.handleRemoveOrgRunner)
 	mux.HandleFunc("POST /v1/actions/orgs/{organization}/runners/preflight", m.handleOrgPreflight)
+	mux.HandleFunc("POST /v1/actions/repos/{owner}/{repo}/workflows/{workflow}/dispatches", m.handleDispatchWorkflow)
 	return mux
 }
 
@@ -533,6 +560,29 @@ func (m *githubRunnerProviderModule) handleOrgPreflight(w http.ResponseWriter, r
 		return
 	}
 	writeProviderResponse(w, http.StatusOK, out)
+}
+
+func (m *githubRunnerProviderModule) handleDispatchWorkflow(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Ref string `json:"ref"`
+	}
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeProviderError(w, http.StatusBadRequest, fmt.Errorf("decode request: %w", err))
+		return
+	}
+	out, err := m.invokeMethod(r.Context(), "dispatch_workflow", map[string]any{
+		"repository":     r.PathValue("owner") + "/" + r.PathValue("repo"),
+		"workflow":       r.PathValue("workflow"),
+		"ref":            req.Ref,
+		"provider_token": bearerToken(r),
+	})
+	if err != nil {
+		writeProviderError(w, providerErrorStatus(err), err)
+		return
+	}
+	writeProviderResponse(w, http.StatusNoContent, out)
 }
 
 func bearerToken(r *http.Request) string {

--- a/internal/runner_provider_test.go
+++ b/internal/runner_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,6 +92,34 @@ func TestT593_GitHubRunnerClientPreflightChecksPaginatedOrgRunnerLabels(t *testi
 	}
 	if len(result.ConflictingLabels) != 1 || result.ConflictingLabels[0] != "wfc-ghp-stg" {
 		t.Fatalf("conflicting labels: got %+v", result.ConflictingLabels)
+	}
+}
+
+func TestT915_GitHubRunnerClientDispatchesWorkflow(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method: got %q want POST", r.Method)
+		}
+		if r.URL.Path != "/repos/GoCodeAlone/workflow-compute/actions/workflows/dogfood.yml/dispatches" {
+			t.Fatalf("path: got %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer github-token" {
+			t.Fatalf("authorization header: got %q", r.Header.Get("Authorization"))
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["ref"] != "main" {
+			t.Fatalf("body: %+v", body)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := &httpGitHubRunnerClient{baseURL: server.URL, httpClient: server.Client()}
+	if err := client.DispatchWorkflow(context.Background(), "GoCodeAlone", "workflow-compute", "dogfood.yml", "main", "github-token"); err != nil {
+		t.Fatalf("dispatch workflow: %v", err)
 	}
 }
 
@@ -254,6 +283,38 @@ func TestT41_GitHubRunnerProviderHTTPRejectsUnallowlistedRepository(t *testing.T
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("status: got %d want 403", resp.StatusCode)
+	}
+}
+
+func TestT915_GitHubRunnerProviderHTTPDispatchesWorkflow(t *testing.T) {
+	fake := &fakeRunnerClient{}
+	module, err := newGitHubRunnerProviderModule("provider", map[string]any{
+		"token":          "github-token",
+		"provider_token": "provider-token",
+		"repositories":   []any{"GoCodeAlone/workflow-compute"},
+	}, fake)
+	if err != nil {
+		t.Fatalf("module: %v", err)
+	}
+	server := httptest.NewServer(module.HTTPHandler())
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches", strings.NewReader(`{"ref":"main"}`))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer provider-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("provider request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status: got %d body=%s", resp.StatusCode, readResponseBody(t, resp))
+	}
+	if fake.dispatchedRepository != "GoCodeAlone/workflow-compute" || fake.dispatchedWorkflow != "dogfood.yml" || fake.dispatchedRef != "main" {
+		t.Fatalf("dispatch: repo=%q workflow=%q ref=%q", fake.dispatchedRepository, fake.dispatchedWorkflow, fake.dispatchedRef)
 	}
 }
 
@@ -459,6 +520,9 @@ type fakeRunnerClient struct {
 	removedRunnerID             int64
 	preflight                   GitHubRunnerProviderPreflight
 	preflightOrganization       string
+	dispatchedRepository        string
+	dispatchedWorkflow          string
+	dispatchedRef               string
 }
 
 func (f *fakeRunnerClient) RegistrationToken(_ context.Context, owner, repo, _ string) (GitHubRunnerRegistrationToken, error) {
@@ -488,6 +552,13 @@ func (f *fakeRunnerClient) PreflightOrg(_ context.Context, req GitHubRunnerProvi
 	return f.preflight, nil
 }
 
+func (f *fakeRunnerClient) DispatchWorkflow(_ context.Context, owner, repo, workflow, ref, _ string) error {
+	f.dispatchedRepository = owner + "/" + repo
+	f.dispatchedWorkflow = workflow
+	f.dispatchedRef = ref
+	return nil
+}
+
 func writeRunnerProviderJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
@@ -495,4 +566,13 @@ func writeRunnerProviderJSON(t *testing.T, w http.ResponseWriter, status int, v 
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		t.Fatalf("encode response: %v", err)
 	}
+}
+
+func readResponseBody(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	return string(data)
 }


### PR DESCRIPTION
## Summary
- Teaches `github-actions-runner-job` to consume the workflow-compute dynamic provider envelope from stdin instead of being spec-only.
- Adds a plugin-owned provider sidecar dispatch endpoint so the runner job can trigger `workflow_dispatch` without putting GitHub provider logic or tokens in workflow-compute.
- Adds a Dockerfile for a real provider runtime image based on GitHub's official `actions-runner` image.

## Notes
- The runtime uses `COMPUTE_GITHUB_RUNNER_PROVIDER_URL` and `COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN`; the sidecar keeps the GitHub token.
- The container creates `github-runner-proof.json` and emits it via the dynamic-provider artifact list.
- GHCR push is blocked locally by missing `write:packages`: `denied: permission_denied: The token provided does not match expected scopes`. Local arm64/amd64 images build and run spec mode.

## TDD / regression proof
- RED: `GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915 -count=1` failed with `undefined: runWithIO` before command runtime wiring.
- RED: `GOWORK=off go test ./internal -run TestT915_GitHubRunner -count=1` failed with `client.DispatchWorkflow undefined` before sidecar dispatch support.
- GREEN: `GOWORK=off go test ./... -count=1`.

## Local image proof
- Built `ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:dev-arm64` locally, image id `sha256:6c5f4b88f0b653b42dba47f81f8b12e06c266b1935c2243d9b0c38eeb9bdc5a9`.
- Built `ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:dev-amd64` locally, image id `sha256:00b569de36c25995193cc21ac50a94da7a8de93f6513dc1d377b464aed1c2ad1`.
- `docker run --rm --platform linux/arm64 -i ...:dev-arm64 --spec` emitted the expected deterministic runner spec.
- `docker run --rm --platform linux/amd64 -i ...:dev-amd64 --spec` emitted the expected deterministic runner spec.

## Adversarial self-review
- Provider-boundary check: GitHub API dispatch stays in `workflow-plugin-github`; workflow-compute only passes generic env and envelope.
- One-sided boundary check: covered command stdin envelope, sidecar bearer auth, sidecar HTTP dispatch, GitHub API dispatch, and runner script execution with hermetic tests.
- Residual blocker: image publication to GHCR still needs `write:packages` auth or a functioning release workflow.

## Verification
- `git diff --check`
- `GOWORK=off go test ./... -count=1`
