### PR TITLE
Publish GitHub runner job image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,12 +71,52 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ github.ref_name }} --draft=false --repo ${{ github.repository }}
 
+  publish-runner-job-image:
+    name: Publish runner-job image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Build runner-job binaries for image
+        env:
+          CGO_ENABLED: "0"
+          GOPRIVATE: github.com/GoCodeAlone/*
+          GONOSUMCHECK: github.com/GoCodeAlone/*
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          GOOS=linux GOARCH=amd64 go build -o dist/github-actions-runner-job-linux-amd64 ./cmd/github-actions-runner-job
+          GOOS=linux GOARCH=arm64 go build -o dist/github-actions-runner-job-linux-arm64 ./cmd/github-actions-runner-job
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: cmd/github-actions-runner-job/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:${{ github.ref_name }}
+            ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:latest
+
   notify-workflow-registry:
     name: Notify workflow-registry
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: release
+    needs: [release, publish-runner-job-image]
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
   publish-runner-job-image:
     name: Publish runner-job image
     runs-on: ubuntu-latest
+    needs: release
+    if: >-
+      !github.event.deleted
+      && !contains(github.ref_name, '-')
+      && github.repository == 'GoCodeAlone/workflow-plugin-github'
     permissions:
       contents: read
       packages: write
@@ -116,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [release, publish-runner-job-image]
+    needs: publish-runner-job-image
     if: >-
       !github.event.deleted
       && !contains(github.ref_name, '-')

--- a/release_packaging_test.go
+++ b/release_packaging_test.go
@@ -52,6 +52,33 @@ func TestReleaseArchiveIncludesGitHubActionsRunnerJob(t *testing.T) {
 	}
 }
 
+func TestReleasePublishesGitHubActionsRunnerJobImage(t *testing.T) {
+	data, err := os.ReadFile(".github/workflows/release.yml")
+	if err != nil {
+		t.Fatalf("read release workflow: %v", err)
+	}
+	workflow := string(data)
+
+	for _, want := range []string{
+		"packages: write",
+		"GOOS=linux GOARCH=amd64 go build -o dist/github-actions-runner-job-linux-amd64 ./cmd/github-actions-runner-job",
+		"GOOS=linux GOARCH=arm64 go build -o dist/github-actions-runner-job-linux-arm64 ./cmd/github-actions-runner-job",
+		"docker/login-action@",
+		"docker/setup-buildx-action@",
+		"docker/build-push-action@",
+		"context: .",
+		"file: cmd/github-actions-runner-job/Dockerfile",
+		"platforms: linux/amd64,linux/arm64",
+		"push: true",
+		"ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:${{ github.ref_name }}",
+		"ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:latest",
+	} {
+		if !strings.Contains(workflow, want) {
+			t.Fatalf("release workflow must include %q so the runner-job image is available to workflow-compute agents", want)
+		}
+	}
+}
+
 func TestReleaseArchiveCheckRejectsProviderBuildOutsideArchive(t *testing.T) {
 	config := `
 builds:

--- a/release_packaging_test.go
+++ b/release_packaging_test.go
@@ -58,8 +58,20 @@ func TestReleasePublishesGitHubActionsRunnerJobImage(t *testing.T) {
 		t.Fatalf("read release workflow: %v", err)
 	}
 	workflow := string(data)
+	topPermissions := topLevelSection(workflow, "permissions:")
+	if strings.Contains(topPermissions, "packages:") {
+		t.Fatal("release workflow must not grant packages permissions at workflow scope")
+	}
+
+	job := workflowJobSection(workflow, "publish-runner-job-image")
+	if job == "" {
+		t.Fatal("release workflow must define publish-runner-job-image job")
+	}
 
 	for _, want := range []string{
+		"needs: release",
+		"!contains(github.ref_name, '-')",
+		"github.repository == 'GoCodeAlone/workflow-plugin-github'",
 		"packages: write",
 		"GOOS=linux GOARCH=amd64 go build -o dist/github-actions-runner-job-linux-amd64 ./cmd/github-actions-runner-job",
 		"GOOS=linux GOARCH=arm64 go build -o dist/github-actions-runner-job-linux-arm64 ./cmd/github-actions-runner-job",
@@ -73,8 +85,8 @@ func TestReleasePublishesGitHubActionsRunnerJobImage(t *testing.T) {
 		"ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:${{ github.ref_name }}",
 		"ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:latest",
 	} {
-		if !strings.Contains(workflow, want) {
-			t.Fatalf("release workflow must include %q so the runner-job image is available to workflow-compute agents", want)
+		if !strings.Contains(job, want) {
+			t.Fatalf("publish-runner-job-image job must include %q so the runner-job image is available to workflow-compute agents", want)
 		}
 	}
 }
@@ -134,6 +146,26 @@ func topLevelSection(config, header string) string {
 			section = append(section, next)
 		}
 		return strings.Join(section, "\n")
+	}
+	return ""
+}
+
+func workflowJobSection(config, jobName string) string {
+	lines := strings.Split(config, "\n")
+	marker := "  " + jobName + ":"
+	for i, line := range lines {
+		if line != marker {
+			continue
+		}
+
+		item := []string{line}
+		for _, next := range lines[i+1:] {
+			if strings.HasPrefix(next, "  ") && !strings.HasPrefix(next, "    ") {
+				break
+			}
+			item = append(item, next)
+		}
+		return strings.Join(item, "\n")
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- publish the github-actions-runner-job OCI image from the tag release workflow
- build linux/amd64 and linux/arm64 runner-job binaries with the exact filenames consumed by the Dockerfile
- add a release-packaging guard so future release workflow edits keep the image publication contract intact

## Verification
- RED: `GOWORK=off go test . -run TestReleasePublishesGitHubActionsRunnerJobImage -count=1` failed before the workflow edit with missing `packages: write`
- GREEN: `GOWORK=off go test . -run TestReleasePublishesGitHubActionsRunnerJobImage -count=1` passed
- `GOWORK=off go test ./... -count=1` passed
- `git diff --check` passed
- `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOWORK=off go build -o dist/github-actions-runner-job-linux-amd64 ./cmd/github-actions-runner-job` passed
- `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GOWORK=off go build -o dist/github-actions-runner-job-linux-arm64 ./cmd/github-actions-runner-job` passed
- `docker build --platform linux/amd64 -f cmd/github-actions-runner-job/Dockerfile -t ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:test-amd64 .` passed
- `docker build --platform linux/arm64 -f cmd/github-actions-runner-job/Dockerfile -t ghcr.io/gocodealone/workflow-plugin-github/github-actions-runner-job:test-arm64 .` passed

## Adversarial self-review
- Found and fixed over-broad workflow `packages: write` permission by moving it to the image publish job.
- Checked Dockerfile boundary: release job now emits `dist/github-actions-runner-job-linux-{amd64,arm64}`, matching `TARGETARCH` expansion in `cmd/github-actions-runner-job/Dockerfile`.
- Checked downstream release ordering: workflow-registry notification now waits for both archive release and image publication.

## Notes
- Existing `v1.0.11` release completed and registry notification succeeded, but it does not publish this image. A new tag after this PR is merged is needed to publish the GHCR image used by workflow-compute STG agents.