### PR TITLE
[codex] Pass GitHub runner workflow dispatch inputs

### DIFF
--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -274,7 +274,7 @@ func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.Ephemeral
 func (d *runnerDriver) workflowDispatchInputs(spec internal.EphemeralRunnerJobSpec) (map[string]string, error) {
 	inputs := make(map[string]string, len(d.req.WorkflowInputs)+5)
 	for key, value := range d.req.WorkflowInputs {
-		key = strings.TrimSpace(key)
+		key = strings.ToLower(strings.TrimSpace(key))
 		if key == "" {
 			continue
 		}

--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -166,13 +166,17 @@ func (c *providerSidecarClient) orgRegistrationToken(ctx context.Context, organi
 	return out, nil
 }
 
-func (c *providerSidecarClient) dispatchWorkflow(ctx context.Context, repository, workflow, ref string) error {
+func (c *providerSidecarClient) dispatchWorkflow(ctx context.Context, repository, workflow, ref string, inputs map[string]string) error {
 	owner, repo, err := splitRepository(repository)
 	if err != nil {
 		return err
 	}
 	path := "/v1/actions/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(repo) + "/workflows/" + url.PathEscape(workflow) + "/dispatches"
-	return c.do(ctx, http.MethodPost, path, map[string]any{"ref": ref}, http.StatusNoContent, nil)
+	body := map[string]any{"ref": ref}
+	if len(inputs) > 0 {
+		body["inputs"] = inputs
+	}
+	return c.do(ctx, http.MethodPost, path, body, http.StatusNoContent, nil)
 }
 
 func (c *providerSidecarClient) removeOrgRunner(ctx context.Context, organization string, runnerID int64) error {
@@ -244,7 +248,11 @@ func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.Ephemeral
 		if ref == "" {
 			ref = "main"
 		}
-		if err := d.sidecar.dispatchWorkflow(ctx, d.req.Repository, d.req.Workflow, ref); err != nil {
+		inputs, err := d.workflowDispatchInputs(spec)
+		if err != nil {
+			return internal.EphemeralRunnerJobResult{}, err
+		}
+		if err := d.sidecar.dispatchWorkflow(ctx, d.req.Repository, d.req.Workflow, ref, inputs); err != nil {
 			return internal.EphemeralRunnerJobResult{}, err
 		}
 	}
@@ -261,6 +269,27 @@ func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.Ephemeral
 		Labels:        append([]string(nil), spec.Labels...),
 		CleanupStatus: "removed",
 	}, nil
+}
+
+func (d *runnerDriver) workflowDispatchInputs(spec internal.EphemeralRunnerJobSpec) (map[string]string, error) {
+	inputs := make(map[string]string, len(d.req.WorkflowInputs)+5)
+	for key, value := range d.req.WorkflowInputs {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		inputs[key] = value
+	}
+	labels, err := json.Marshal(spec.Labels)
+	if err != nil {
+		return nil, fmt.Errorf("marshal workflow runner labels: %w", err)
+	}
+	inputs["runner_profile"] = "provider"
+	inputs["allow_github_hosted_fallback"] = "false"
+	inputs["runner_labels_json"] = string(labels)
+	inputs["stg_task_id"] = d.req.TaskID
+	inputs["workflow_compute_provider_task"] = d.req.TaskID
+	return inputs, nil
 }
 
 func (d *runnerDriver) RemoveOrgRunner(ctx context.Context, organization string, runnerID int64) error {

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -47,6 +47,11 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 					t.Fatalf("dispatch input %s: got %q want %q; body=%#v", key, got, want, body.Inputs)
 				}
 			}
+			for _, forbidden := range []string{"Runner_Profile", "ALLOW_GITHUB_HOSTED_FALLBACK", "Custom"} {
+				if _, ok := body.Inputs[forbidden]; ok {
+					t.Fatalf("dispatch inputs must normalize caller keys, found %q in %#v", forbidden, body.Inputs)
+				}
+			}
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/actions/orgs/GoCodeAlone/runners/42":
 			deleteCalls++
@@ -84,7 +89,7 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 	    "workflow":"dogfood.yml",
 	    "ref":"main",
 	    "runner_group":"ephemeral",
-	    "workflow_inputs":{"custom":"kept"}
+	    "workflow_inputs":{"Custom":"kept","Runner_Profile":"manual","ALLOW_GITHUB_HOSTED_FALLBACK":"true"}
 	  }
 	}`)
 	var stdout, stderr bytes.Buffer

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -24,6 +24,29 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 			_, _ = w.Write([]byte(`{"token":"runner-registration-token","expires_at":"2026-06-26T22:00:00Z"}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches":
 			dispatchCalls++
+			var body struct {
+				Ref    string            `json:"ref"`
+				Inputs map[string]string `json:"inputs"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode dispatch body: %v", err)
+			}
+			if body.Ref != "main" {
+				t.Fatalf("dispatch ref: got %q", body.Ref)
+			}
+			wantLabels := `["self-hosted","linux","wfc-stg-ghp-linux-01234567-abcdef98","wfc-ghp-stg","wfc-ghp-ephemeral"]`
+			for key, want := range map[string]string{
+				"runner_profile":                 "provider",
+				"allow_github_hosted_fallback":   "false",
+				"runner_labels_json":             wantLabels,
+				"stg_task_id":                    "task-abcdef9876543210",
+				"workflow_compute_provider_task": "task-abcdef9876543210",
+				"custom":                         "kept",
+			} {
+				if got := body.Inputs[key]; got != want {
+					t.Fatalf("dispatch input %s: got %q want %q; body=%#v", key, got, want, body.Inputs)
+				}
+			}
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/actions/orgs/GoCodeAlone/runners/42":
 			deleteCalls++
@@ -60,7 +83,8 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 	    "repository":"GoCodeAlone/workflow-compute",
 	    "workflow":"dogfood.yml",
 	    "ref":"main",
-	    "runner_group":"ephemeral"
+	    "runner_group":"ephemeral",
+	    "workflow_inputs":{"custom":"kept"}
 	  }
 	}`)
 	var stdout, stderr bytes.Buffer

--- a/internal/ephemeral_runner_job.go
+++ b/internal/ephemeral_runner_job.go
@@ -29,6 +29,7 @@ type EphemeralRunnerJobRequest struct {
 	Repository          string                 `json:"repository,omitempty"`
 	Workflow            string                 `json:"workflow,omitempty"`
 	Ref                 string                 `json:"ref,omitempty"`
+	WorkflowInputs      map[string]string      `json:"workflow_inputs,omitempty"`
 	RunnerGroup         string                 `json:"runner_group,omitempty"`
 	Timeout             time.Duration          `json:"-"`
 	RequiredRuntimeCaps []string               `json:"required_runtime_caps,omitempty"`

--- a/internal/module_runner_provider.go
+++ b/internal/module_runner_provider.go
@@ -917,6 +917,7 @@ func ephemeralRunnerJobRequestFromArgs(args map[string]any) (EphemeralRunnerJobR
 		Repository:          stringArg(args, "repository"),
 		Workflow:            stringArg(args, "workflow"),
 		Ref:                 stringArg(args, "ref"),
+		WorkflowInputs:      stringMapArg(args["workflow_inputs"]),
 		RunnerGroup:         stringArg(args, "runner_group"),
 		RequiredRuntimeCaps: stringListArg(args["required_runtime_caps"]),
 		AdvertisedCaps:      stringListArg(args["advertised_caps"]),
@@ -926,6 +927,36 @@ func ephemeralRunnerJobRequestFromArgs(args map[string]any) (EphemeralRunnerJobR
 func stringArg(args map[string]any, key string) string {
 	value, _ := args[key].(string)
 	return strings.TrimSpace(value)
+}
+
+func stringMapArg(value any) map[string]string {
+	switch v := value.(type) {
+	case map[string]string:
+		out := make(map[string]string, len(v))
+		for key, val := range v {
+			key = strings.TrimSpace(key)
+			if key != "" {
+				out[key] = val
+			}
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]string, len(v))
+		for key, val := range v {
+			key = strings.TrimSpace(key)
+			if key == "" {
+				continue
+			}
+			str, ok := val.(string)
+			if !ok {
+				continue
+			}
+			out[key] = str
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 func int64Arg(args map[string]any, key string) (int64, error) {

--- a/internal/module_runner_provider.go
+++ b/internal/module_runner_provider.go
@@ -934,7 +934,7 @@ func stringMapArg(value any) map[string]string {
 	case map[string]string:
 		out := make(map[string]string, len(v))
 		for key, val := range v {
-			key = strings.TrimSpace(key)
+			key = strings.ToLower(strings.TrimSpace(key))
 			if key != "" {
 				out[key] = val
 			}
@@ -943,7 +943,7 @@ func stringMapArg(value any) map[string]string {
 	case map[string]any:
 		out := make(map[string]string, len(v))
 		for key, val := range v {
-			key = strings.TrimSpace(key)
+			key = strings.ToLower(strings.TrimSpace(key))
 			if key == "" {
 				continue
 			}


### PR DESCRIPTION
## Summary

- passes generated runner labels/task metadata into GitHub workflow_dispatch inputs for ephemeral runner jobs
- preserves caller-supplied workflow_inputs while overriding provider-owned safety inputs
- covers the dynamic provider command path that dispatches dogfood target workflows

## Root Cause

The GitHub runner job provider dispatched workflows with only `{ "ref": "main" }`. The workflow-compute dogfood target needs the generated runner label array and STG task id as dispatch inputs, so the provider-backed workflow would queue on the default placeholder labels or fail required-input validation instead of targeting the ephemeral runner it just registered.

## Verification

- `GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go build ./cmd/github-actions-runner-job`
- `GOWORK=off go build ./cmd/github-runner-provider`
- `git diff --check`

## Regression Proof

With production fix reverted and the new test retained:

```
$ GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner -count=1
FAIL — decode ephemeral runner request: json: unknown field "workflow_inputs"
```

With fix restored:

```
$ GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner -count=1
ok github.com/GoCodeAlone/workflow-plugin-github/cmd/github-actions-runner-job
```
