### PR TITLE
Extract GitHub runner job under workspace

### DIFF
--- a/cmd/github-actions-runner-job/Dockerfile
+++ b/cmd/github-actions-runner-job/Dockerfile
@@ -29,7 +29,7 @@ COPY --chmod=0755 ${RUNNER_JOB_BINARY} /usr/local/bin/github-actions-runner-job
 COPY --chmod=0755 cmd/github-actions-runner-job/entrypoint.sh /usr/local/bin/github-actions-runner-job-entrypoint
 
 USER runner
-WORKDIR /home/runner
+WORKDIR /workspace
 ENV GITHUB_ACTIONS_RUNNER_ARCHIVE=/opt/actions-runner/actions-runner.tar.gz
-ENV GITHUB_ACTIONS_RUNNER_DIR=/home/runner/actions-runner
+ENV GITHUB_ACTIONS_RUNNER_DIR=/workspace/.github-actions-runner
 ENTRYPOINT ["/usr/local/bin/github-actions-runner-job-entrypoint"]

--- a/cmd/github-actions-runner-job/Dockerfile
+++ b/cmd/github-actions-runner-job/Dockerfile
@@ -23,7 +23,9 @@ RUN set -eux; \
   echo "${runner_sha256}  /opt/actions-runner/actions-runner.tar.gz" | sha256sum -c -; \
   tar -tzf /opt/actions-runner/actions-runner.tar.gz ./config.sh ./run.sh >/dev/null; \
   chmod 0644 /opt/actions-runner/actions-runner.tar.gz; \
-  useradd -m -s /bin/bash runner
+  useradd -m -s /bin/bash runner; \
+  mkdir -p /workspace; \
+  chown runner:runner /workspace
 
 COPY --chmod=0755 ${RUNNER_JOB_BINARY} /usr/local/bin/github-actions-runner-job
 COPY --chmod=0755 cmd/github-actions-runner-job/entrypoint.sh /usr/local/bin/github-actions-runner-job-entrypoint

--- a/cmd/github-actions-runner-job/entrypoint.sh
+++ b/cmd/github-actions-runner-job/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 archive="${GITHUB_ACTIONS_RUNNER_ARCHIVE:-/opt/actions-runner/actions-runner.tar.gz}"
-runner_dir="${GITHUB_ACTIONS_RUNNER_DIR:-/home/runner/actions-runner}"
+runner_dir="${GITHUB_ACTIONS_RUNNER_DIR:-/workspace/.github-actions-runner}"
 
 if [ ! -f "$archive" ]; then
   echo "github-actions-runner-job: runner archive not found at $archive" >&2
@@ -10,6 +10,7 @@ if [ ! -f "$archive" ]; then
 fi
 
 if [ ! -x "$runner_dir/config.sh" ]; then
+  mkdir -p "$(dirname "$runner_dir")"
   mkdir -p "$runner_dir"
   tar --no-same-owner -xzf "$archive" -C "$runner_dir"
 fi

--- a/release_packaging_test.go
+++ b/release_packaging_test.go
@@ -109,7 +109,8 @@ func TestGitHubActionsRunnerJobImageCarriesCompressedRunnerArchive(t *testing.T)
 		`echo "${runner_sha256}  /opt/actions-runner/actions-runner.tar.gz" | sha256sum -c -`,
 		"tar -tzf /opt/actions-runner/actions-runner.tar.gz ./config.sh ./run.sh >/dev/null",
 		"GITHUB_ACTIONS_RUNNER_ARCHIVE=/opt/actions-runner/actions-runner.tar.gz",
-		"GITHUB_ACTIONS_RUNNER_DIR=/home/runner/actions-runner",
+		"GITHUB_ACTIONS_RUNNER_DIR=/workspace/.github-actions-runner",
+		"WORKDIR /workspace",
 		"COPY --chmod=0755 cmd/github-actions-runner-job/entrypoint.sh /usr/local/bin/github-actions-runner-job-entrypoint",
 		`ENTRYPOINT ["/usr/local/bin/github-actions-runner-job-entrypoint"]`,
 	} {
@@ -125,15 +126,21 @@ func TestGitHubActionsRunnerJobImageCarriesCompressedRunnerArchive(t *testing.T)
 	entrypointText := string(entrypoint)
 	for _, want := range []string{
 		"${GITHUB_ACTIONS_RUNNER_ARCHIVE:-/opt/actions-runner/actions-runner.tar.gz}",
-		"${GITHUB_ACTIONS_RUNNER_DIR:-/home/runner/actions-runner}",
+		"${GITHUB_ACTIONS_RUNNER_DIR:-/workspace/.github-actions-runner}",
 		`[ ! -f "$archive" ]`,
 		"runner archive not found",
+		`mkdir -p "$(dirname "$runner_dir")"`,
 		`tar --no-same-owner -xzf "$archive" -C "$runner_dir"`,
 		`exec /usr/local/bin/github-actions-runner-job "$@"`,
 	} {
 		if !strings.Contains(entrypointText, want) {
 			t.Fatalf("runner job entrypoint must include %q", want)
 		}
+	}
+	if strings.Contains(dockerfile, "WORKDIR /home/runner") ||
+		strings.Contains(dockerfile, "GITHUB_ACTIONS_RUNNER_DIR=/home/runner/actions-runner") ||
+		strings.Contains(entrypointText, "GITHUB_ACTIONS_RUNNER_DIR:-/home/runner/actions-runner") {
+		t.Fatal("runner job image must extract the runner under the writable /workspace mount, not /home/runner")
 	}
 }
 

--- a/release_packaging_test.go
+++ b/release_packaging_test.go
@@ -108,6 +108,8 @@ func TestGitHubActionsRunnerJobImageCarriesCompressedRunnerArchive(t *testing.T)
 		`arm64) runner_sha256="69ac7e5692f877189e7dddf4a1bb16cbbd6425568cd69a0359895fac48b9ad3b"`,
 		`echo "${runner_sha256}  /opt/actions-runner/actions-runner.tar.gz" | sha256sum -c -`,
 		"tar -tzf /opt/actions-runner/actions-runner.tar.gz ./config.sh ./run.sh >/dev/null",
+		"mkdir -p /workspace",
+		"chown runner:runner /workspace",
 		"GITHUB_ACTIONS_RUNNER_ARCHIVE=/opt/actions-runner/actions-runner.tar.gz",
 		"GITHUB_ACTIONS_RUNNER_DIR=/workspace/.github-actions-runner",
 		"WORKDIR /workspace",


### PR DESCRIPTION
## Summary
- extract the bundled GitHub Actions runner under `/workspace/.github-actions-runner` instead of `/home/runner/actions-runner`
- keep the runner-job image compatible with workflow-compute's read-only rootfs sandbox and `/workspace:rw` mount
- extend release packaging coverage so future image changes cannot regress to `/home/runner`

## Root cause
Retained STG Linux diagnostics showed the provider-owned runner image started under workflow-compute, then failed in the entrypoint with:

```
mkdir: cannot create directory '/home/runner': Permission denied
```

The dynamic provider sandbox uses a read-only root filesystem and a writable `/workspace` mount, so runner extraction must happen under `/workspace`.

## TDD / regression proof
With the packaging test updated first and the Dockerfile/entrypoint reverted to `/home/runner`, the focused test failed with the expected missing `/workspace` assertion.

With the fix restored:

```
$ GOWORK=off go test ./... -count=1
ok   github.com/GoCodeAlone/workflow-plugin-github
ok   github.com/GoCodeAlone/workflow-plugin-github/cmd/github-actions-runner-job
ok   github.com/GoCodeAlone/workflow-plugin-github/internal
```

```
$ GOWORK=off go build ./cmd/github-actions-runner-job
# exit 0
```

## Runtime launch validation
Ran the real image locally with the workflow-compute sandbox shape:

```
docker run --rm -i --read-only --cap-drop ALL --security-opt no-new-privileges \
  --pids-limit 256 --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m \
  --user "$(id -u):$(id -g)" -v "$tmp:/workspace:rw" -w /workspace \
  workflow-plugin-github-runner-job:local --spec
```

Evidence:
- exit code 0
- output contained deterministic runner name/labels
- extracted `/workspace/.github-actions-runner/config.sh`
- extracted `/workspace/.github-actions-runner/run.sh`

## Adversarial self-review
- Checked one-sided boundary wiring: the image now writes only to the sandbox writable mount used by workflow-compute.
- Checked cross-platform/runtime mismatch: workflow-compute overrides image `USER` with host UID/GID; the launch validation includes that shape.
- Checked regression coverage: tests reject `WORKDIR /home/runner` and the old `GITHUB_ACTIONS_RUNNER_DIR` fallback.
- Checked artifact/env leakage: no secrets or runner tokens are added to tests or PR evidence.
