### PR TITLE
[codex] Forward runner dispatch inputs

### DIFF
--- a/internal/module_runner_provider.go
+++ b/internal/module_runner_provider.go
@@ -32,7 +32,7 @@ type GitHubRunnerClient interface {
 	OrgRegistrationToken(ctx context.Context, organization, token string) (GitHubRunnerRegistrationToken, error)
 	RemoveOrgRunner(ctx context.Context, organization string, runnerID int64, token string) error
 	PreflightOrg(ctx context.Context, req GitHubRunnerProviderPreflightRequest, token string) (GitHubRunnerProviderPreflight, error)
-	DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref, token string) error
+	DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref string, inputs map[string]string, token string) error
 }
 
 type GitHubRunnerRegistrationToken struct {
@@ -172,12 +172,16 @@ func (c *httpGitHubRunnerClient) PreflightOrg(ctx context.Context, req GitHubRun
 	}, nil
 }
 
-func (c *httpGitHubRunnerClient) DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref, token string) error {
+func (c *httpGitHubRunnerClient) DispatchWorkflow(ctx context.Context, owner, repo, workflow, ref string, inputs map[string]string, token string) error {
 	if strings.TrimSpace(ref) == "" {
 		ref = "main"
 	}
 	endpoint := fmt.Sprintf("%s/repos/%s/%s/actions/workflows/%s/dispatches", c.baseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(workflow))
-	return c.do(ctx, http.MethodPost, endpoint, map[string]any{"ref": ref}, token, http.StatusNoContent, nil)
+	body := map[string]any{"ref": ref}
+	if len(inputs) > 0 {
+		body["inputs"] = inputs
+	}
+	return c.do(ctx, http.MethodPost, endpoint, body, token, http.StatusNoContent, nil)
 }
 
 func (c *httpGitHubRunnerClient) do(ctx context.Context, method, endpoint string, body any, token string, wantStatus int, out any) error {
@@ -427,7 +431,8 @@ func (m *githubRunnerProviderModule) invokeMethod(ctx context.Context, method st
 			return nil, errors.New("workflow is required")
 		}
 		ref := stringArg(args, "ref")
-		if err := m.client.DispatchWorkflow(ctx, owner, repo, workflow, ref, m.config.Token); err != nil {
+		inputs := stringMapArg(args["inputs"])
+		if err := m.client.DispatchWorkflow(ctx, owner, repo, workflow, ref, inputs, m.config.Token); err != nil {
 			return nil, err
 		}
 		return map[string]any{}, nil
@@ -564,7 +569,8 @@ func (m *githubRunnerProviderModule) handleOrgPreflight(w http.ResponseWriter, r
 
 func (m *githubRunnerProviderModule) handleDispatchWorkflow(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Ref string `json:"ref"`
+		Ref    string            `json:"ref"`
+		Inputs map[string]string `json:"inputs,omitempty"`
 	}
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
 	decoder.DisallowUnknownFields()
@@ -576,6 +582,7 @@ func (m *githubRunnerProviderModule) handleDispatchWorkflow(w http.ResponseWrite
 		"repository":     r.PathValue("owner") + "/" + r.PathValue("repo"),
 		"workflow":       r.PathValue("workflow"),
 		"ref":            req.Ref,
+		"inputs":         req.Inputs,
 		"provider_token": bearerToken(r),
 	})
 	if err != nil {

--- a/internal/runner_provider_test.go
+++ b/internal/runner_provider_test.go
@@ -113,12 +113,22 @@ func TestT915_GitHubRunnerClientDispatchesWorkflow(t *testing.T) {
 		if body["ref"] != "main" {
 			t.Fatalf("body: %+v", body)
 		}
+		inputs, ok := body["inputs"].(map[string]any)
+		if !ok {
+			t.Fatalf("inputs: got %#v", body["inputs"])
+		}
+		if inputs["runner_profile"] != "provider" || inputs["allow_github_hosted_fallback"] != "false" {
+			t.Fatalf("inputs: got %+v", inputs)
+		}
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
 	client := &httpGitHubRunnerClient{baseURL: server.URL, httpClient: server.Client()}
-	if err := client.DispatchWorkflow(context.Background(), "GoCodeAlone", "workflow-compute", "dogfood.yml", "main", "github-token"); err != nil {
+	if err := client.DispatchWorkflow(context.Background(), "GoCodeAlone", "workflow-compute", "dogfood.yml", "main", map[string]string{
+		"runner_profile":               "provider",
+		"allow_github_hosted_fallback": "false",
+	}, "github-token"); err != nil {
 		t.Fatalf("dispatch workflow: %v", err)
 	}
 }
@@ -299,7 +309,7 @@ func TestT915_GitHubRunnerProviderHTTPDispatchesWorkflow(t *testing.T) {
 	server := httptest.NewServer(module.HTTPHandler())
 	defer server.Close()
 
-	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches", strings.NewReader(`{"ref":"main"}`))
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches", strings.NewReader(`{"ref":"main","inputs":{"runner_profile":"provider","allow_github_hosted_fallback":"false"}}`))
 	if err != nil {
 		t.Fatalf("request: %v", err)
 	}
@@ -315,6 +325,12 @@ func TestT915_GitHubRunnerProviderHTTPDispatchesWorkflow(t *testing.T) {
 	}
 	if fake.dispatchedRepository != "GoCodeAlone/workflow-compute" || fake.dispatchedWorkflow != "dogfood.yml" || fake.dispatchedRef != "main" {
 		t.Fatalf("dispatch: repo=%q workflow=%q ref=%q", fake.dispatchedRepository, fake.dispatchedWorkflow, fake.dispatchedRef)
+	}
+	if got := fake.dispatchedInputs["runner_profile"]; got != "provider" {
+		t.Fatalf("runner_profile input: got %q", got)
+	}
+	if got := fake.dispatchedInputs["allow_github_hosted_fallback"]; got != "false" {
+		t.Fatalf("allow_github_hosted_fallback input: got %q", got)
 	}
 }
 
@@ -523,6 +539,7 @@ type fakeRunnerClient struct {
 	dispatchedRepository        string
 	dispatchedWorkflow          string
 	dispatchedRef               string
+	dispatchedInputs            map[string]string
 }
 
 func (f *fakeRunnerClient) RegistrationToken(_ context.Context, owner, repo, _ string) (GitHubRunnerRegistrationToken, error) {
@@ -552,10 +569,11 @@ func (f *fakeRunnerClient) PreflightOrg(_ context.Context, req GitHubRunnerProvi
 	return f.preflight, nil
 }
 
-func (f *fakeRunnerClient) DispatchWorkflow(_ context.Context, owner, repo, workflow, ref, _ string) error {
+func (f *fakeRunnerClient) DispatchWorkflow(_ context.Context, owner, repo, workflow, ref string, inputs map[string]string, _ string) error {
 	f.dispatchedRepository = owner + "/" + repo
 	f.dispatchedWorkflow = workflow
 	f.dispatchedRef = ref
+	f.dispatchedInputs = inputs
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Forward workflow_dispatch inputs through the GitHub runner provider sidecar.
- Keep the runner-provider HTTP boundary strict: `inputs` must decode as `map[string]string`.
- Add regression coverage for both the sidecar HTTP endpoint and the GitHub API client request body.

## Root cause
`github-actions-runner-job` sends `inputs` when dispatching `dogfood-provider-target.yml`, but the released provider sidecar only decoded `ref` with `DisallowUnknownFields`. Once the retained Linux agent could reach a live sidecar, the sidecar would reject the request before a workflow run could be dispatched.

## Verification
- `GOWORK=off go test ./internal -run 'GitHubRunnerProviderHTTPDispatchesWorkflow|GitHubRunnerClientDispatchesWorkflow' -count=1`
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go build -o /tmp/wfc-github-runner-provider ./cmd/github-runner-provider`
- `GOWORK=off go build -o /tmp/wfc-github-actions-runner-job ./cmd/github-actions-runner-job`
- `git diff --check`

## Regression proof
With the production fix reverted and the tests retained:

```text
$ GOWORK=off go test ./internal -run 'GitHubRunnerProviderHTTPDispatchesWorkflow|GitHubRunnerClientDispatchesWorkflow' -count=1
--- FAIL: TestT915_GitHubRunnerClientDispatchesWorkflow
    runner_provider_test.go:118: inputs: got <nil>
--- FAIL: TestT915_GitHubRunnerProviderHTTPDispatchesWorkflow
    runner_provider_test.go:324: status: got 400 body={"error":"decode request: json: unknown field \"inputs\""}
FAIL
```

With the fix restored:

```text
$ GOWORK=off go test ./internal -run 'GitHubRunnerProviderHTTPDispatchesWorkflow|GitHubRunnerClientDispatchesWorkflow' -count=1
ok  github.com/GoCodeAlone/workflow-plugin-github/internal  0.739s
```

## Adversarial self-review
- One-sided boundary wiring: checked sender, sidecar handler, module invocation, and GitHub client request body. Covered by focused tests.
- Type coercion: `inputs` stays `map[string]string`; non-string payloads still fail closed at HTTP decode or are ignored by existing internal map coercion.
- Scope creep: no workflow-compute or runner lifecycle changes in this PR.
- Secret leakage: no tokens, URLs, or artifact contents added to logs/tests.
