### PR TITLE
[codex] Start ephemeral runner before dispatch

### DIFF
--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -363,7 +363,8 @@ type runningCommand struct {
 	path   string
 	cancel context.CancelFunc
 	cmd    *exec.Cmd
-	output bytes.Buffer
+	stdout bytes.Buffer
+	stderr bytes.Buffer
 }
 
 func startCommand(ctx context.Context, path, dir string, args ...string) (*runningCommand, error) {
@@ -372,8 +373,8 @@ func startCommand(ctx context.Context, path, dir string, args ...string) (*runni
 	cmd.Dir = dir
 	cmd.Env = os.Environ()
 	running := &runningCommand{path: path, cancel: cancel, cmd: cmd}
-	cmd.Stdout = &running.output
-	cmd.Stderr = &running.output
+	cmd.Stdout = &running.stdout
+	cmd.Stderr = &running.stderr
 	if err := cmd.Start(); err != nil {
 		cancel()
 		return nil, fmt.Errorf("%s start failed: %w", filepath.Base(path), err)
@@ -385,7 +386,8 @@ func (r *runningCommand) wait() error {
 	err := r.cmd.Wait()
 	r.cancel()
 	if err != nil {
-		return fmt.Errorf("%s failed: %w: %s", filepath.Base(r.path), err, strings.TrimSpace(r.output.String()))
+		output := strings.TrimSpace(strings.Join([]string{r.stdout.String(), r.stderr.String()}, "\n"))
+		return fmt.Errorf("%s failed: %w: %s", filepath.Base(r.path), err, output)
 	}
 	return nil
 }

--- a/cmd/github-actions-runner-job/main.go
+++ b/cmd/github-actions-runner-job/main.go
@@ -240,35 +240,49 @@ func (d *runnerDriver) RunGitHubJob(ctx context.Context, mode internal.Ephemeral
 	if mode == "" {
 		mode = internal.EphemeralRunnerJobModeAttachToQueued
 	}
+	var dispatchRef string
+	var dispatchInputs map[string]string
 	if mode == internal.EphemeralRunnerJobModeDispatchThenWait {
 		if strings.TrimSpace(d.req.Workflow) == "" || strings.TrimSpace(d.req.Repository) == "" {
 			return internal.EphemeralRunnerJobResult{}, fmt.Errorf("repository and workflow are required for %s", mode)
 		}
-		ref := strings.TrimSpace(d.req.Ref)
-		if ref == "" {
-			ref = "main"
+		dispatchRef = strings.TrimSpace(d.req.Ref)
+		if dispatchRef == "" {
+			dispatchRef = "main"
 		}
 		inputs, err := d.workflowDispatchInputs(spec)
 		if err != nil {
 			return internal.EphemeralRunnerJobResult{}, err
 		}
-		if err := d.sidecar.dispatchWorkflow(ctx, d.req.Repository, d.req.Workflow, ref, inputs); err != nil {
-			return internal.EphemeralRunnerJobResult{}, err
-		}
+		dispatchInputs = inputs
 	}
 	if err := d.configureRunner(ctx, spec, token.Token); err != nil {
 		return internal.EphemeralRunnerJobResult{}, err
 	}
-	runnerID := d.runnerID()
-	if err := d.runRunner(ctx); err != nil {
-		return internal.EphemeralRunnerJobResult{}, err
+	result := internal.EphemeralRunnerJobResult{
+		RunnerID:   d.runnerID(),
+		RunnerName: spec.RunnerName,
+		Labels:     append([]string(nil), spec.Labels...),
 	}
-	return internal.EphemeralRunnerJobResult{
-		RunnerID:      runnerID,
-		RunnerName:    spec.RunnerName,
-		Labels:        append([]string(nil), spec.Labels...),
-		CleanupStatus: "removed",
-	}, nil
+	if mode == internal.EphemeralRunnerJobModeDispatchThenWait {
+		runner, err := d.startRunner(ctx)
+		if err != nil {
+			return result, err
+		}
+		if err := d.sidecar.dispatchWorkflow(ctx, d.req.Repository, d.req.Workflow, dispatchRef, dispatchInputs); err != nil {
+			runner.cancel()
+			_ = runner.wait()
+			return result, err
+		}
+		if err := runner.wait(); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+	if err := d.runRunner(ctx); err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 func (d *runnerDriver) workflowDispatchInputs(spec internal.EphemeralRunnerJobSpec) (map[string]string, error) {
@@ -316,6 +330,10 @@ func (d *runnerDriver) runRunner(ctx context.Context) error {
 	return runCommand(ctx, filepath.Join(d.runnerDir, "run.sh"), d.runnerDir, "--once")
 }
 
+func (d *runnerDriver) startRunner(ctx context.Context) (*runningCommand, error) {
+	return startCommand(ctx, filepath.Join(d.runnerDir, "run.sh"), d.runnerDir, "--once")
+}
+
 func (d *runnerDriver) runnerID() int64 {
 	data, err := os.ReadFile(filepath.Join(d.runnerDir, ".runner"))
 	if err != nil {
@@ -337,6 +355,37 @@ func runCommand(ctx context.Context, path, dir string, args ...string) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s failed: %w: %s", filepath.Base(path), err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+type runningCommand struct {
+	path   string
+	cancel context.CancelFunc
+	cmd    *exec.Cmd
+	output bytes.Buffer
+}
+
+func startCommand(ctx context.Context, path, dir string, args ...string) (*runningCommand, error) {
+	runCtx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(runCtx, path, args...)
+	cmd.Dir = dir
+	cmd.Env = os.Environ()
+	running := &runningCommand{path: path, cancel: cancel, cmd: cmd}
+	cmd.Stdout = &running.output
+	cmd.Stderr = &running.output
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, fmt.Errorf("%s start failed: %w", filepath.Base(path), err)
+	}
+	return running, nil
+}
+
+func (r *runningCommand) wait() error {
+	err := r.cmd.Wait()
+	r.cancel()
+	if err != nil {
+		return fmt.Errorf("%s failed: %w: %s", filepath.Base(r.path), err, strings.TrimSpace(r.output.String()))
 	}
 	return nil
 }

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testing.T) {
 	var tokenCalls, dispatchCalls, deleteCalls int
+	workspace := t.TempDir()
 	sidecar := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer provider-token" {
 			t.Fatalf("authorization = %q", got)
@@ -24,6 +26,17 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 			_, _ = w.Write([]byte(`{"token":"runner-registration-token","expires_at":"2026-06-26T22:00:00Z"}`))
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/actions/repos/GoCodeAlone/workflow-compute/workflows/dogfood.yml/dispatches":
 			dispatchCalls++
+			runStarted := filepath.Join(workspace, "run.started")
+			for range 20 {
+				if _, err := os.Stat(runStarted); err == nil {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			if _, err := os.Stat(runStarted); err != nil {
+				http.Error(w, "runner listener was not started before dispatch", http.StatusConflict)
+				return
+			}
 			var body struct {
 				Ref    string            `json:"ref"`
 				Inputs map[string]string `json:"inputs"`
@@ -52,6 +65,9 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 					t.Fatalf("dispatch inputs must normalize caller keys, found %q in %#v", forbidden, body.Inputs)
 				}
 			}
+			if err := os.WriteFile(filepath.Join(workspace, "dispatch.seen"), []byte("1\n"), 0o600); err != nil {
+				t.Fatalf("write dispatch marker: %v", err)
+			}
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/actions/orgs/GoCodeAlone/runners/42":
 			deleteCalls++
@@ -64,8 +80,7 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 
 	runnerDir := t.TempDir()
 	writeExecutable(t, filepath.Join(runnerDir, "config.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/config.args\"\nprintf '{\"agentId\":42}\\n' > .runner\n")
-	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.args\"\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
-	workspace := t.TempDir()
+	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.args\"\ntouch \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.started\"\nwhile [ ! -f \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/dispatch.seen\" ]; do sleep 0.1; done\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
 	t.Chdir(workspace)
 	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_URL", sidecar.URL)
 	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN", "provider-token")

--- a/cmd/github-actions-runner-job/main_test.go
+++ b/cmd/github-actions-runner-job/main_test.go
@@ -80,7 +80,7 @@ func TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner(t *testin
 
 	runnerDir := t.TempDir()
 	writeExecutable(t, filepath.Join(runnerDir, "config.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/config.args\"\nprintf '{\"agentId\":42}\\n' > .runner\n")
-	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.args\"\ntouch \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.started\"\nwhile [ ! -f \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/dispatch.seen\" ]; do sleep 0.1; done\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
+	writeExecutable(t, filepath.Join(runnerDir, "run.sh"), "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.args\"\ntouch \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.started\"\nwhile [ ! -f \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/dispatch.seen\" ]; do sleep 0.1; done\n(for i in $(seq 1 50); do printf 'stdout-%s\\n' \"$i\"; done) &\n(for i in $(seq 1 50); do printf 'stderr-%s\\n' \"$i\" >&2; done) &\nwait\nprintf 'runner executed\\n' > \"$GITHUB_ACTIONS_RUNNER_JOB_TEST_DIR/run.log\"\n")
 	t.Chdir(workspace)
 	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_URL", sidecar.URL)
 	t.Setenv("COMPUTE_GITHUB_RUNNER_PROVIDER_TOKEN", "provider-token")


### PR DESCRIPTION
## Summary
- Start the ephemeral GitHub Actions runner process before dispatching `dispatch_then_wait` workflows.
- Return partial runner metadata on run/dispatch errors so the existing cleanup layer can still remove registered runners.
- Add a regression test that fails if workflow dispatch happens before the fake runner listener has started.

## Root Cause
`github-actions-runner-job` dispatched the target workflow before running `config.sh`/`run.sh --once`. If runner registration or listener startup failed after dispatch, the GitHub target run remained queued with no matching `wfc-ghp-*` runner visible at the org level. This matched the STG evidence from task `github-provider-dogfood-linux-20260630115322`: STG task leased, zero proofs, GitHub target run queued, and no ephemeral org runner registered.

## Adversarial Self-Review
- Found and fixed side effects before validation: the implementation now validates required dispatch inputs and builds dispatch inputs before configuring a runner.
- Found and fixed premature cleanup claims: the driver no longer pre-fills `cleanup_status=removed`; the existing cleanup layer assigns the final status after removal.

## Verification
- RED with implementation reverted: `GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner -count=1` failed with `runner listener was not started before dispatch`.
- GREEN: `GOWORK=off go test ./cmd/github-actions-runner-job -run TestT915CommandRunsDynamicProviderEnvelopeThroughSidecarAndRunner -count=1` passed.
- `GOWORK=off go test ./cmd/github-actions-runner-job ./internal -run 'EphemeralRunner|RunnerProvider|T915' -count=1` passed.
- `GOWORK=off go build ./cmd/github-actions-runner-job` passed.
- `GOWORK=off go test ./... -count=1` passed after rebase onto `origin/main`/`v1.0.18`.
- `git diff --check` passed.

## Supersedes
- Replaces draft PR #38, which was opened from a stale branch and could not be force-pushed under autonomous safety hooks.
