### PR TITLE
Authenticate GitHub runner provider readiness

### DIFF
--- a/internal/module_runner_provider.go
+++ b/internal/module_runner_provider.go
@@ -1540,6 +1540,7 @@ func validateEphemeralRunnerJobArgs(args map[string]any) error {
 func (m *githubRunnerProviderModule) HTTPHandler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", m.handleHealth)
+	mux.HandleFunc("GET /readyz", m.handleReadiness)
 	mux.HandleFunc("POST /v1/actions/runners/registration-token", m.handleRegistrationToken)
 	mux.HandleFunc("DELETE /v1/actions/runners/{runner_id}", m.handleRemoveRunner)
 	mux.HandleFunc("POST /v1/actions/orgs/{organization}/runners/registration-token", m.handleOrgRegistrationToken)
@@ -1556,6 +1557,19 @@ func (m *githubRunnerProviderModule) HTTPHandler() http.Handler {
 }
 
 func (m *githubRunnerProviderModule) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeProviderResponse(w, http.StatusOK, map[string]any{"status": "ok"})
+}
+
+func (m *githubRunnerProviderModule) handleReadiness(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeProviderError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+		return
+	}
+	if err := m.authorizeProvider(map[string]any{"provider_token": bearerToken(r)}); err != nil {
+		writeProviderError(w, providerErrorStatus(err), err)
+		return
+	}
 	writeProviderResponse(w, http.StatusOK, map[string]any{"status": "ok"})
 }
 
@@ -1845,9 +1859,16 @@ func parseOptionalRFC3339Query(value, name string) (time.Time, error) {
 }
 
 func bearerToken(r *http.Request) string {
-	value := r.Header.Get("Authorization")
+	values := r.Header.Values("Authorization")
+	if len(values) != 1 {
+		return ""
+	}
+	value := values[0]
+	if strings.TrimSpace(value) != value {
+		return ""
+	}
 	token, ok := strings.CutPrefix(value, "Bearer ")
-	if !ok {
+	if !ok || token == "" || strings.ContainsAny(token, " \t\r\n") {
 		return ""
 	}
 	return token

--- a/internal/runner_provider_test.go
+++ b/internal/runner_provider_test.go
@@ -1035,6 +1035,108 @@ func TestT44_GitHubRunnerProviderServesHealthz(t *testing.T) {
 	}
 }
 
+func TestT916GitHubRunnerProviderReadyzRequiresProviderBearer(t *testing.T) {
+	module, err := newGitHubRunnerProviderModule("provider", map[string]any{
+		"token":          "github-token",
+		"provider_token": "provider-token",
+		"repositories":   []any{"example/repository"},
+	}, &fakeRunnerClient{})
+	if err != nil {
+		t.Fatalf("module: %v", err)
+	}
+	server := httptest.NewServer(module.HTTPHandler())
+	defer server.Close()
+
+	unauthorizedCases := []struct {
+		name          string
+		authorization []string
+	}{
+		{name: "missing"},
+		{name: "bare token", authorization: []string{"provider-token"}},
+		{name: "bare bearer", authorization: []string{"Bearer"}},
+		{name: "empty bearer", authorization: []string{"Bearer "}},
+		{name: "basic", authorization: []string{"Basic provider-token"}},
+		{name: "lowercase scheme", authorization: []string{"bearer provider-token"}},
+		{name: "extra whitespace", authorization: []string{"Bearer  provider-token"}},
+		{name: "wrong token", authorization: []string{"Bearer submitted-wrong-token"}},
+		{name: "duplicate", authorization: []string{"Bearer provider-token", "Bearer submitted-wrong-token"}},
+	}
+	for _, tc := range unauthorizedCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, requestErr := http.NewRequest(http.MethodGet, server.URL+"/readyz", nil)
+			if requestErr != nil {
+				t.Fatalf("request: %v", requestErr)
+			}
+			for _, authorization := range tc.authorization {
+				req.Header.Add("Authorization", authorization)
+			}
+			resp, requestErr := server.Client().Do(req)
+			if requestErr != nil {
+				t.Fatalf("readiness request: %v", requestErr)
+			}
+			body, readErr := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("read unauthorized response: %v", readErr)
+			}
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("readiness status: got %d want %d body=%s", resp.StatusCode, http.StatusUnauthorized, body)
+			}
+			if string(body) != "{\"error\":\"provider token is invalid\"}\n" {
+				t.Fatalf("unauthorized body: got %q", body)
+			}
+			for _, token := range []string{"provider-token", "submitted-wrong-token"} {
+				if strings.Contains(string(body), token) {
+					t.Fatalf("unauthorized response exposed token %q", token)
+				}
+			}
+		})
+	}
+
+	directReq := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	directReq.Header["Authorization"] = []string{"Bearer provider-token "}
+	directResp := httptest.NewRecorder()
+	module.HTTPHandler().ServeHTTP(directResp, directReq)
+	if directResp.Code != http.StatusUnauthorized {
+		t.Fatalf("direct trailing-whitespace status: got %d want %d", directResp.Code, http.StatusUnauthorized)
+	}
+
+	headReq, err := http.NewRequest(http.MethodHead, server.URL+"/readyz", nil)
+	if err != nil {
+		t.Fatalf("HEAD request: %v", err)
+	}
+	headReq.Header.Set("Authorization", "Bearer provider-token")
+	headResp, err := server.Client().Do(headReq)
+	if err != nil {
+		t.Fatalf("HEAD readiness request: %v", err)
+	}
+	_ = headResp.Body.Close()
+	if headResp.StatusCode != http.StatusMethodNotAllowed || headResp.Header.Get("Allow") != http.MethodGet {
+		t.Fatalf("HEAD readiness response: status=%d allow=%q", headResp.StatusCode, headResp.Header.Get("Allow"))
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/readyz", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer provider-token")
+	resp, err := server.Client().Do(req)
+	if err != nil {
+		t.Fatalf("authenticated readiness request: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated readiness status: got %d want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read readiness response: %v", err)
+	}
+	if string(body) != "{\"status\":\"ok\"}\n" {
+		t.Fatalf("readiness response: got %q", body)
+	}
+}
+
 func TestT916GitHubRunnerProviderHTTPRejectsConcatenatedJSON(t *testing.T) {
 	module, err := newGitHubRunnerProviderModule("provider", map[string]any{
 		"token":          "github-token",


### PR DESCRIPTION
## Summary
- add provider-owned authenticated `GET /readyz` while preserving public `/healthz` liveness
- reject missing, malformed, whitespace-bearing, and duplicate bearer headers
- keep failure responses generic and token-free

## Security boundary
This provides the authenticated TLS readiness probe needed by the retained workflow-compute STG sidecar. It reuses constant-time provider-token authorization and adds no workflow-compute awareness. The persistent token remains STG POC-only; product auth still requires short-lived scoped credentials with rotation, revocation, and audit.

## Regression proof
With the `/readyz` route removed:
```
TestT916GitHubRunnerProviderReadyzRequiresProviderBearer: got 404 want 401
FAIL
```

With the route restored:
```
TestT916GitHubRunnerProviderReadyzRequiresProviderBearer: PASS
```

## Verification
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off go vet ./...`
- `GOWORK=off go build ./cmd/github-runner-provider`
- adversarial review: SHIP-IT; all five Minor coverage findings resolved before push
